### PR TITLE
Fix sub node name in the Winter 2018 e-5 map json file

### DIFF
--- a/kcauto-kai.sikuli/maps/E-5.json
+++ b/kcauto-kai.sikuli/maps/E-5.json
@@ -6,7 +6,7 @@
 			"coords": [167, 289],
 			"types": ["air"]
 		},
-		"C": {
+		"B": {
 			"coords": [194, 230],
 			"types": ["sub"]
 		},


### PR DESCRIPTION
The sub node in Winter 2018 E-5 map is node B not node C. Node C is a no battle node.