### PR TITLE
fix out of bounds error when checking repair timer and repair time co…

### DIFF
--- a/kcauto-kai.sikuli/repair.sikuli/repair.py
+++ b/kcauto-kai.sikuli/repair.sikuli/repair.py
@@ -254,10 +254,14 @@ class RepairModule(object):
         """Method to update the Combat module's next sortie timer based on the
         shortest timer in the internal repair timers list.
         """
-        self.repair_timers.sort()
-        shortest_timer = self.repair_timers[0]
+        if len(self.repair_timers) > 0:
+            if len(self.repair_timers) > 1:
+                self.repair_timers.sort()
+            shortest_timer = self.repair_timers[0]
+        else:
+            shortest_timer = datetime.now()
 
-        if shortest_timer > self.combat.next_combat_time:
+        if shortest_timer < self.combat.next_combat_time:
             self.combat.next_combat_time = shortest_timer + timedelta(
                 minutes=1)
             Util.log_msg("Delaying next combat sortie to {}".format(

--- a/kcauto-kai.sikuli/repair.sikuli/repair.py
+++ b/kcauto-kai.sikuli/repair.sikuli/repair.py
@@ -254,14 +254,10 @@ class RepairModule(object):
         """Method to update the Combat module's next sortie timer based on the
         shortest timer in the internal repair timers list.
         """
-        if len(self.repair_timers) > 0:
-            if len(self.repair_timers) > 1:
-                self.repair_timers.sort()
-            shortest_timer = self.repair_timers[0]
-        else:
-            shortest_timer = datetime.now()
+        self.repair_timers.sort()
+        shortest_timer = self.repair_timers[0]
 
-        if shortest_timer < self.combat.next_combat_time:
+        if shortest_timer > self.combat.next_combat_time:
             self.combat.next_combat_time = shortest_timer + timedelta(
                 minutes=1)
             Util.log_msg("Delaying next combat sortie to {}".format(

--- a/kcauto-kai.sikuli/repair.sikuli/repair.py
+++ b/kcauto-kai.sikuli/repair.sikuli/repair.py
@@ -103,7 +103,8 @@ class RepairModule(object):
                 else:
                     # no empty docks, so just exit out of loop
                     break
-        self._update_combat_next_sortie_time()
+        if len(self.repair_timers) > dock_busy_count:
+            self._update_combat_next_sortie_time()
 
     def _conduct_repair(self):
         """Method that chooses an empty dock, chooses a ship, toggles the


### PR DESCRIPTION
As per #158  if there is currently nothing else being repaired and a bucket is used on the current repair, the script will crash upon trying to set the next shortest repair timer because the list is empty.

I also believe you have the time comparison flipped?
